### PR TITLE
fix expectation of .string with a button group

### DIFF
--- a/pyside2uic/uiparser.py
+++ b/pyside2uic/uiparser.py
@@ -211,7 +211,7 @@ class UIParser(object):
         elif isinstance(widget, QtWidgets.QAbstractButton):
             bg_i18n = self.wprops.getAttribute(elem, "buttonGroup")
             if bg_i18n is not None:
-                bg_name = bg_i18n.string
+                bg_name = bg_i18n
 
                 for bg in self.button_groups:
                     if bg.objectName() == bg_name:


### PR DESCRIPTION
fix compile issues with button groups, since it isn't a qwidget anymore.

  File "C:\bl\pkgs\blizzard\bl\pkg\bfd\ext\pyside\5.6.3+bfd.12\install\windows_x64_msvc14_release_python2.7\lib\python\site-packages\pyside2uic\uiparser.py", line 214, in createWidget
    bg_name = bg_i18n.string